### PR TITLE
Fix mobile viewport

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -4,6 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="viewport" content="initial-scale=1.0">
         <title>Open Haskell - $title$</title>
         <link rel="stylesheet" type="text/css" href="/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="/css/foundation.min.css" />
@@ -28,9 +29,9 @@
 
       <div class="row">
         <div class="large-9 columns" role="content">
-          
+
           <h1>$title$</h1>
-          
+
           $body$
         </div>
         <div id="footer">


### PR DESCRIPTION
I think this meta property will improve the site on mobile.

![Without viewport scale](https://cloud.githubusercontent.com/assets/1770543/13550241/bfe54dec-e319-11e5-9de1-923ac869c7f6.png)

![With viewport scale](https://cloud.githubusercontent.com/assets/1770543/13550242/bffe2d26-e319-11e5-9f58-0609f60b8803.png)
