### PR TITLE
Switch to the latest Stackage LTS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.1
+resolver: lts-5.5
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
I don't know if it changes something but it compiles with the latest Stackage LTS (5.5). If you don't want to switch (for some reasons I don't know, I'm a Haskell newbie ^^) just close the merge request :-)
